### PR TITLE
fix: improve lint config and cross-platform paths

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,8 +16,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - name: Extract Python version
+      id: py
+      run: |
+        echo "version=$(grep -oP 'target-version\s*=\s*"py\K[0-9]+' pyproject.toml)" >> "$GITHUB_OUTPUT"
+
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: "${{ steps.py.outputs.version }}"
 
     - name: Install dependencies
       shell: bash

--- a/aeonview.py
+++ b/aeonview.py
@@ -227,7 +227,7 @@ class AeonViewVideos:
         year_month = f"{self.year}-{self.month}"
 
         input_dir = AeonViewHelpers.build_path(
-            self.path_videos, year_month, self.day
+            self.path_images, year_month, self.day
         )
         output_dir = AeonViewHelpers.build_path(self.path_videos, year_month)
         output_file = AeonViewHelpers.build_path(output_dir, f"{self.day}.mp4")
@@ -240,7 +240,7 @@ class AeonViewVideos:
 
         if not self.simulate:
             logging.info("Running ffmpeg command: %s", " ".join(ffmpeg_cmd))
-            if not os.path.exists(input_dir):
+            if not os.path.exists(output_dir):
                 AeonViewHelpers.mkdir_p(output_dir)
             subprocess.run(ffmpeg_cmd, check=True)
             logging.info(

--- a/aeonview_test.py
+++ b/aeonview_test.py
@@ -23,8 +23,8 @@ default_timeframe = "daily"
 default_simulate = False
 default_verbose = False
 default_image_domain = "https://example.com/image"
-default_test_path = Path("/tmp/test_project").resolve()
-tmp_images = Path("/tmp/images")
+default_test_path = Path(tempfile.gettempdir(), "test_project").resolve()
+tmp_images = Path(tempfile.gettempdir(), "images")
 
 
 def test_build_path_resolves_correctly():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ testpaths = ["."]
 python_files = ["*_test.py"]
 
 [tool.pylint.MAIN]
-ignore-patterns='^\.#'
-ignore-paths='^\.#'
-ignore='CVS,.venv'
-disable='attribute-defined-outside-init,invalid-name,missing-docstring,protected-access,too-many-instance-attributes,too-few-public-methods,format'
+ignore-patterns = ["^\\.#"]
+ignore-paths = ["^\\.#"]
+ignore = ["CVS", ".venv"]
+disable = 'attribute-defined-outside-init,invalid-name,missing-docstring,protected-access,too-many-instance-attributes,too-few-public-methods,format'


### PR DESCRIPTION
## Summary
- fix pylint config arrays in pyproject
- reference Python version from pyproject in CI
- make temp paths platform independent
- correct video input/output handling

## Testing
- `pre-commit run --files .github/workflows/python-tests.yml aeonview.py aeonview_test.py pyproject.toml` *(fails: Could not install deps)*
- `make test` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68754d3adfa0832fba35cad3d9474693